### PR TITLE
Fixed interference with 'Use Latest Version' option

### DIFF
--- a/build.py
+++ b/build.py
@@ -52,7 +52,6 @@ def process_json( addon, version ):
         json_obj = json.load(f)
         json_obj["id"] = json_id
         json_obj["time"] = time
-        json_obj["releaseTime"] = time
         json_obj["libraries"].insert(0,{"name":lib_id}) #Insert at beginning
         json_obj["libraries"].append({"name":"net.minecraft:Minecraft:"+mc_version}) #Insert at end
         return json.dumps( json_obj, indent=1 )

--- a/installer/1.7.10-nohydra.json
+++ b/installer/1.7.10-nohydra.json
@@ -1,7 +1,7 @@
 {
   "id": "Vivecraft-1.7.10-Vivecraft-$VERSION",
   "time": "2014-05-14T18:29:23+01:00",
-  "releaseTime": "2014-05-14T18:29:23+01:00",
+  "releaseTime": "1960-01-01T07:00:00+00:00",
   "type": "release",
   "minecraftArguments": "--username ${auth_player_name} --version ${version_name} --gameDir ${game_directory} --assetsDir ${assets_root} --assetIndex ${assets_index_name} --uuid ${auth_uuid} --accessToken ${auth_access_token} --userProperties ${user_properties} --userType ${user_type}  --tweakClass optifine.OptiFineTweaker",
   "libraries": [

--- a/installer/1.7.10.json
+++ b/installer/1.7.10.json
@@ -1,7 +1,7 @@
 {
   "id": "1.7.10-Vivecraft-$VERSION",
   "time": "2014-05-14T18:29:23+01:00",
-  "releaseTime": "2014-05-14T18:29:23+01:00",
+  "releaseTime": "1960-01-01T07:00:00+00:00",
   "type": "release",
   "minecraftArguments": "--username ${auth_player_name} --version ${version_name} --gameDir ${game_directory} --assetsDir ${assets_root} --assetIndex ${assets_index_name} --uuid ${auth_uuid} --accessToken ${auth_access_token} --userProperties ${user_properties} --userType ${user_type}  --tweakClass optifine.OptiFineTweaker",
   "libraries": [


### PR DESCRIPTION
This'll move vivecraft to the bottom of the version list, so the launcher stops assuming that it's the latest version of minecraft.
