### PR TITLE
Move Forge RenderTickEvent into drawFramebuffer() so it actually works

### DIFF
--- a/patches/net/minecraft/client/Minecraft.java.patch
+++ b/patches/net/minecraft/client/Minecraft.java.patch
@@ -100,7 +100,7 @@
  import net.minecraft.world.EnumDifficulty;
  import net.minecraft.world.WorldProviderEnd;
  import net.minecraft.world.WorldProviderHell;
-@@ -150,2988 +168,4754 @@
+@@ -150,2988 +168,4768 @@
  import net.minecraft.world.storage.ISaveFormat;
  import net.minecraft.world.storage.ISaveHandler;
  import net.minecraft.world.storage.WorldInfo;
@@ -2868,10 +2868,24 @@
 +			this.mcProfiler.endSection();
 +			this.mcProfiler.startSection("render");
 +
++			Object fmlCommonHandler = null;
++			if (Reflector.FMLCommonHandler_instance.exists()) {
++				fmlCommonHandler = Reflector.call(Reflector.FMLCommonHandler_instance, new Object[0]);
++			}
++			if (!this.stereoProvider.isGuiOrtho()) {
++				if (fmlCommonHandler != null) { // Not sure how this event is even useful, so we'll just fire it before binding the GUI framebuffer.
++					Reflector.callVoid(fmlCommonHandler, Reflector.FMLCommonHandler_onRenderTickStart, new Object[]{this.timer.renderPartialTicks});
++				}
++			}
 +			// Render GUI to FBO if necessary
 +			this.framebufferMc = this.guiFramebuffer; //draw to 2d gui.
 +			this.framebufferMc.bindFramebuffer(true);
 +			this.entityRenderer.drawFramebuffer(this.timer.renderPartialTicks, var6);   // VIVE - added param for debug info
++			//if (!this.stereoProvider.isGuiOrtho()) { // Useless here
++			//	if (fmlCommonHandler != null) {
++			//		Reflector.callVoid(fmlCommonHandler, Reflector.FMLCommonHandler_onRenderTickEnd, new Object[]{this.timer.renderPartialTicks});
++			//	}
++			//}
 +				
 +			// Mark beginning of frame AFTER any GUI rendering to allow maximum
 +			// latency reduction
@@ -2954,12 +2968,10 @@
 +					if (!this.skipRenderWorld)
 +					{
 +						/** MINECRIFT FORGE **/
-+						Object fmlCommonHandler = null;
-+						if (Reflector.FMLCommonHandler_instance.exists()) {
-+							fmlCommonHandler = Reflector.call(Reflector.FMLCommonHandler_instance, new Object[0]);
-+						}
-+						if (fmlCommonHandler != null) {
-+							Reflector.callVoid(fmlCommonHandler, Reflector.FMLCommonHandler_onRenderTickStart, new Object[]{this.timer.renderPartialTicks});
++						if (this.stereoProvider.isGuiOrtho()) {
++							if (fmlCommonHandler != null) {
++								Reflector.callVoid(fmlCommonHandler, Reflector.FMLCommonHandler_onRenderTickStart, new Object[]{this.timer.renderPartialTicks});
++							}
 +						}
 +						this.mcProfiler.endStartSection("gameRenderer");
 +	
@@ -2967,8 +2979,10 @@
 +						this.entityRenderer.updateCameraAndRender(this.timer.renderPartialTicks);
 +						
 +						this.mcProfiler.endSection();
-+						if (fmlCommonHandler != null) {
-+							Reflector.callVoid(fmlCommonHandler, Reflector.FMLCommonHandler_onRenderTickEnd, new Object[]{this.timer.renderPartialTicks});
++						if (this.stereoProvider.isGuiOrtho()) {
++							if (fmlCommonHandler != null) {
++								Reflector.callVoid(fmlCommonHandler, Reflector.FMLCommonHandler_onRenderTickEnd, new Object[]{this.timer.renderPartialTicks});
++							}
 +						}
 +						/** END MINECRIFT FORGE **/
 +					}

--- a/patches/net/minecraft/client/renderer/EntityRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/EntityRenderer.java.patch
@@ -1861,7 +1861,7 @@
          float clipDistance = this.farPlaneDistance * 2.0F;
  
          if (clipDistance < 128.0F)
-@@ -825,1829 +1142,4033 @@
+@@ -825,1829 +1142,4041 @@
          {
              clipDistance = 256.0F;
          }
@@ -5198,6 +5198,14 @@
 +					this.mc.ingameGUI.renderGameOverlay(renderPartialTicks, this.mc.currentScreen != null, 0, 0);
 +
 +					mc.guiAchievement.updateAchievementWindow();
++					/** MINECRIFT FORGE **/
++					if (Reflector.FMLCommonHandler_instance.exists()) {
++						Object fmlCommonHandler = Reflector.call(Reflector.FMLCommonHandler_instance, new Object[0]);
++						if (fmlCommonHandler != null) {
++							Reflector.callVoid(fmlCommonHandler, Reflector.FMLCommonHandler_onRenderTickEnd, new Object[]{renderPartialTicks});
++						}
++					}
++					/** END MINECRIFT FORGE **/
 +					GL11.glClear(GL11.GL_DEPTH_BUFFER_BIT);
 +				}
 +


### PR DESCRIPTION
This fixes WAILA (issue #75) and probably some other stuff. I only put the RenderTickEvent end phase here, the start phase is fired before the GUI framebuffer is bound as I'm not even sure what you would do in that event, since it's normally called before all other rendering, meaning anything you draw ends up never being seen.
