### PR TITLE
Use optionsBackground from Gui class so we're compatible with Random Things mod

### DIFF
--- a/patches/net/minecraft/client/renderer/EntityRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/EntityRenderer.java.patch
@@ -5072,7 +5072,7 @@
 +		GL11.glEnable(GL11.GL_LIGHT0);
 +		GL11.glEnable(GL11.GL_CULL_FACE);
 +
-+		Minecraft.getMinecraft().renderEngine.bindTexture(new ResourceLocation("textures/gui/options_background.png"));
++		Minecraft.getMinecraft().renderEngine.bindTexture(Gui.optionsBackground);
 +
 +		float yo = -camRelY;
 +		float s = 3f;


### PR DESCRIPTION
Yeah Random Things is just changing the value of Gui.optionsBackground reflectively (somehow? it's final), so just using that works. Stupid simple. Oh, and by "compatible" I mean the dirt room changes to whatever texture Random Things sets for the options background.
