### PR TITLE
Fix sound listener stuff

### DIFF
--- a/patches/net/minecraft/client/Minecraft.java.patch
+++ b/patches/net/minecraft/client/Minecraft.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/client/Minecraft.java
 +++ b/net/minecraft/client/Minecraft.java
-@@ -9,19 +9,40 @@
+@@ -9,19 +9,41 @@
  import com.google.common.util.concurrent.ListenableFutureTask;
  import com.mojang.authlib.minecraft.MinecraftSessionService;
  import com.mojang.authlib.yggdrasil.YggdrasilAuthenticationService;
@@ -13,6 +13,7 @@
 +import com.mtbs3d.minecrift.settings.VRHotkeys;
 +import com.mtbs3d.minecrift.settings.VRSettings;
 +import com.mtbs3d.minecrift.utils.TextureSelector;
++import com.mtbs3d.minecrift.utils.Utils;
 +
 +import de.fruitfly.ovr.enums.EyeType;
 +import de.fruitfly.ovr.structs.*;
@@ -41,7 +42,7 @@
  import java.util.HashSet;
  import java.util.Iterator;
  import java.util.List;
-@@ -30,26 +51,18 @@
+@@ -30,26 +52,18 @@
  import java.util.concurrent.Callable;
  import java.util.concurrent.Executors;
  import java.util.concurrent.FutureTask;
@@ -74,7 +75,7 @@
  import net.minecraft.client.gui.achievement.GuiAchievement;
  import net.minecraft.client.gui.inventory.GuiInventory;
  import net.minecraft.client.gui.stream.GuiStreamUnavailable;
-@@ -97,6 +110,7 @@
+@@ -97,6 +111,7 @@
  import net.minecraft.client.settings.GameSettings;
  import net.minecraft.client.settings.KeyBinding;
  import net.minecraft.client.shader.Framebuffer;
@@ -82,7 +83,7 @@
  import net.minecraft.client.stream.IStream;
  import net.minecraft.client.stream.NullStream;
  import net.minecraft.client.stream.TwitchStream;
-@@ -127,6 +141,8 @@
+@@ -127,6 +142,8 @@
  import net.minecraft.profiler.Profiler;
  import net.minecraft.server.MinecraftServer;
  import net.minecraft.server.integrated.IntegratedServer;
@@ -91,7 +92,7 @@
  import net.minecraft.stats.AchievementList;
  import net.minecraft.stats.IStatStringFormat;
  import net.minecraft.stats.StatFileWriter;
-@@ -142,6 +158,7 @@
+@@ -142,6 +159,7 @@
  import net.minecraft.util.Session;
  import net.minecraft.util.Timer;
  import net.minecraft.util.Util;
@@ -99,7 +100,7 @@
  import net.minecraft.world.EnumDifficulty;
  import net.minecraft.world.WorldProviderEnd;
  import net.minecraft.world.WorldProviderHell;
-@@ -150,2988 +167,4684 @@
+@@ -150,2988 +168,4763 @@
  import net.minecraft.world.storage.ISaveFormat;
  import net.minecraft.world.storage.ISaveHandler;
  import net.minecraft.world.storage.WorldInfo;
@@ -127,6 +128,7 @@
  import org.lwjgl.util.glu.GLU;
 +import org.lwjgl.util.vector.Quaternion;
 +
++import paulscode.sound.SoundSystem;
 +import static java.lang.Math.ceil;
  
  public class Minecraft implements IPlayerUsage
@@ -1774,6 +1776,11 @@
 +	private final boolean isDemo;
 +	private NetworkManager myNetworkManager;
 +	private boolean integratedServerIsRunning;
++	
++	/** Sound system junk */
++	public Field _soundManagerSndSystemField = null;
++	public boolean trySoundSystemReflect = true;
++	public boolean sndSystemReflect = true;
 +
 +	/** The profiler instance */
 +	public final Profiler mcProfiler = new Profiler();
@@ -2877,9 +2884,6 @@
 +			var6 = System.nanoTime() - var5;
 +						
 +			RenderBlocks.fancyGrass = this.gameSettings.fancyGraphics;
-+			this.mcProfiler.startSection("sound");
-+				this.mcSoundHandler.setListener(this.thePlayer, this.timer.renderPartialTicks);
-+			this.mcProfiler.endSection();
 +			
 +			this.mcProfiler.startSection("Gui");
 +			// Render GUI to FBO if necessary
@@ -2897,7 +2901,11 @@
 +			// Poll sensors
 +				MCOpenVR.poll(frameIndex);
 +			this.mcProfiler.endSection();
-+			
++
++			this.mcProfiler.startSection("sound");
++				//this.mcSoundHandler.setListener(this.thePlayer, this.timer.renderPartialTicks);
++				updateSoundListener(); // we update the sound listener from the HMD info
++			this.mcProfiler.endSection();
 +			
 +			//I dunno where to put this.
 +			if(this.stereoProvider.isStereo()){
@@ -7665,6 +7673,78 @@
 +	private long getMedianRunTickTimeNanos()
 +	{
 +		return medianRunTickTimeNanos;
++	}
++
++	/**
++	 * Sets the listener of sounds
++	 */
++	public void updateSoundListener() {
++		SoundSystem sndSystem = null;
++
++		// Get the soundManager from mc.mcSoundHandler (sndManager or field_147694_f)
++		// then get SoundSystem from it (sndSystem or field_148620_e)
++		// Obfuscated names (from MCP908/conf/joined.srg):
++		//    SoundHandler.sndManager = SoundHandler.field_147694_f = btp/a
++		//    stem.sndSystem = SoundSySoundSystem.field_148620_e = btj/e
++
++		// Use reflection to get the sndManager
++		if (sndSystemReflect && _soundManagerSndSystemField == null && this.trySoundSystemReflect) {
++			try {
++				// Get SoundManager from the SoundHandler...
++				Field soundManagerField = Utils.getDeclaredField(mcSoundHandler.getClass(), "sndManager", "f", "field_147694_f");
++				if (soundManagerField != null) {
++					soundManagerField.setAccessible(true);
++					sndManager = (SoundManager)soundManagerField.get(mcSoundHandler);
++				}
++
++				// ...get SoundSystem from SoundManager
++				if (sndManager != null) {
++					_soundManagerSndSystemField = Utils.getDeclaredField(sndManager.getClass(), "sndSystem", "e", "field_148620_e");
++					if (_soundManagerSndSystemField != null) {
++						_soundManagerSndSystemField.setAccessible(true);
++					}
++				}
++			}
++			catch (IllegalAccessException e) {
++				e.printStackTrace();
++			}
++
++			if (_soundManagerSndSystemField == null) {
++				this.trySoundSystemReflect = false;
++				System.out.println("[Minecrift]: FAILED to reflect sndSystem");
++			}
++			else {
++				System.out.println("[Minecrift]: Reflected sndSystem");
++			}
++		}
++
++		if (_soundManagerSndSystemField != null && sndManager != null) {
++			try {
++				sndSystem = (SoundSystem)_soundManagerSndSystemField.get(sndManager);
++			}
++			catch (IllegalArgumentException e) { }
++			catch (IllegalAccessException e) { }
++		}
++
++		// TODO: Set based on head orient (headphones) or body orient (speakers)
++		// ...what? ^
++
++		Vec3 up = roomScale.getCustomHMDVector(Vec3.createVectorHelper(0, 1, 0));
++		Vec3 hmdPos = roomScale.getHMDPos_World();
++		Vec3 hmdDir = roomScale.getHMDDir_World();
++		//synchronized (SoundSystemConfig.THREAD_SYNC) {
++		if (/*SoundManger.soundLibrary != null &&*/ sndSystem != null /* && this.mc.gameSettings.getSoundVolume(SoundCategory // Which sound category?) != 0f // this.mc.gameSettings.soundVolume != 0f */)
++		{
++			// The sound system is on a separate thread? Sync issues? Can get to crash by turning analyglph mode on?
++			try {
++				sndSystem.setListenerPosition((float)hmdPos.xCoord, (float)hmdPos.yCoord, (float)hmdPos.zCoord);
++				sndSystem.setListenerOrientation((float)hmdDir.xCoord, (float)hmdDir.yCoord, (float)hmdDir.zCoord, (float)up.xCoord, (float)up.yCoord, (float)up.zCoord);
++			} catch (NullPointerException what) {} // I don't know
++		}
++		//}
++		if( mumbleLink != null ) {
++			mumbleLink.updateMumble((float)hmdPos.xCoord, (float)hmdPos.yCoord, (float)hmdPos.zCoord, (float)hmdDir.xCoord, (float)hmdDir.yCoord, (float)hmdDir.zCoord, (float)up.xCoord, (float)up.yCoord, (float)up.zCoord);
++		}
 +	}
 +
 +	public final String LANCZOS_SAMPLER_VERTEX_SHADER =

--- a/patches/net/minecraft/client/renderer/EntityRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/EntityRenderer.java.patch
@@ -86,7 +86,7 @@
  import net.minecraft.util.AxisAlignedBB;
  import net.minecraft.util.ChatComponentText;
  import net.minecraft.util.MathHelper;
-@@ -63,736 +88,741 @@
+@@ -63,736 +88,738 @@
  import net.minecraft.world.biome.BiomeGenBase;
  import org.apache.logging.log4j.LogManager;
  import org.apache.logging.log4j.Logger;
@@ -1007,7 +1007,6 @@
 +	/** MINECRIFT */
 +	public int renderpass = 0;
 +	public EulerOrient currentEulerOrientDegrees = new EulerOrient();
-+	public boolean sndSystemReflect = true;
 +	public boolean guiYawOrientationResetRequested = false;
 +	public boolean hudShowingLastFrame = false; //Used for detecting when UI is shown, fixing the guiYaw
 +	public boolean guiScreenShowingThisFrame = false;
@@ -1035,10 +1034,8 @@
 +	Vec3 eyeCollisionBlockPosLoc;
 +	public float headCollisionThresholdDistance = 0.05f;
 +	public float headCollisionDistance = -1f;
-+	public Field _soundManagerSndSystemField = null;
 +	public float clipDistance = 0f;
 +	public float minClipDistance = 0.05f;
-+	public boolean trySoundSystemReflect = true;
 +	public float lookYawOffset = 0;
 +	public float lookPitchOffset = 0;
 +	public int callCount = 0;
@@ -1549,7 +1546,7 @@
          this.farPlaneDistance = (float)(this.mc.gameSettings.renderDistanceChunks * 16);
  
          if (Config.isFogFancy())
-@@ -804,16 +834,14 @@
+@@ -804,16 +831,14 @@
          {
              this.farPlaneDistance *= 0.83F;
          }
@@ -1572,7 +1569,7 @@
          float clipDistance = this.farPlaneDistance * 2.0F;
  
          if (clipDistance < 128.0F)
-@@ -825,1829 +853,4104 @@
+@@ -825,1829 +850,4002 @@
          {
              clipDistance = 256.0F;
          }
@@ -2493,9 +2490,6 @@
 +			getPointedBlock(par1);   // TODO: This needs to be called once, and with the average position
 +			// information for the entire frame, not individual eye pos camRelX, Y, Z
 +		}
-+
-+		// Update sound engine
-+		setSoundListenerOrientation();
 +		/** END MINECRIFT */
 +		this.mc.mcProfiler.endStartSection("center");
 +
@@ -4106,105 +4100,6 @@
 +		GL11.glVertex3f(-(size / 2f), (size * aspect) / 2f, 0.0f);  // Top Left  Of The Texture and Quad
 +
 +		GL11.glEnd();
-+	}
-+
-+
-+
-+	/**
-+	 * Sets the listener of sounds
-+	 */
-+	public void setSoundListenerOrientation()
-+	{
-+		SoundSystem sndSystem = null;
-+
-+		// Get the soundManager from mc.mcSoundHandler (sndManager or field_147694_f)
-+		// then get SoundSystem from it (sndSystem or field_148620_e)
-+		// Obfuscated names (from MCP908/conf/joined.srg):
-+		//    SoundHandler.sndManager = SoundHandler.field_147694_f = btp/a
-+		//    stem.sndSystem = SoundSySoundSystem.field_148620_e = btj/e
-+
-+		// Use reflection to get the sndManager
-+		if (sndSystemReflect && _soundManagerSndSystemField == null && this.trySoundSystemReflect)
-+		{
-+			try
-+			{
-+				// Get SoundManager from the SoundHandler...
-+				Field soundManagerField = Utils.getDeclaredField(mc.mcSoundHandler.getClass(), 
-+						"sndManager", 
-+						"f", 
-+						"field_147694_f");
-+				if (soundManagerField != null)
-+				{
-+					soundManagerField.setAccessible(true);
-+					this.mc.sndManager = (SoundManager) soundManagerField.get(mc.mcSoundHandler);
-+				}
-+
-+				// ...get SoundSystem from SoundManager
-+				if (this.mc.sndManager != null)
-+				{
-+					_soundManagerSndSystemField = Utils.getDeclaredField(this.mc.sndManager.getClass(),
-+							"sndSystem", 
-+							"e", 
-+							"field_148620_e");
-+					if (_soundManagerSndSystemField != null)
-+					{
-+						_soundManagerSndSystemField.setAccessible(true);
-+					}
-+				}
-+			}
-+			catch (IllegalAccessException e)
-+			{
-+				e.printStackTrace();
-+			}
-+
-+			if (_soundManagerSndSystemField == null) {
-+				this.trySoundSystemReflect = false;
-+				System.out.println("[Minecrift]: FAILED to reflect sndSystem");
-+			}
-+			else {
-+				System.out.println("[Minecrift]: Reflected sndSystem");
-+			}
-+		}
-+
-+		if (_soundManagerSndSystemField != null && this.mc.sndManager != null)
-+		{
-+			try
-+			{
-+				sndSystem = (SoundSystem)_soundManagerSndSystemField.get(this.mc.sndManager);
-+			}
-+			catch (IllegalArgumentException e) { }
-+			catch (IllegalAccessException e) { };
-+		}
-+
-+		float PIOVER180 = (float)(Math.PI/180);
-+
-+		// TODO: Set based on head orient (headphones) or body orient (speakers)
-+
-+		Vec3 up = Vec3.createVectorHelper(0, 1, 0);
-+		up.rotateAroundZ(-(float)cameraRoll * PIOVER180);
-+		up.rotateAroundX(-(float)cameraPitch* PIOVER180);
-+		up.rotateAroundY(-(float)cameraYaw  * PIOVER180);
-+		//synchronized (SoundSystemConfig.THREAD_SYNC) {
-+		if (/*SoundManger.soundLibrary != null &&*/ sndSystem != null /* && this.mc.gameSettings.getSoundVolume(SoundCategory // Which sound category?) != 0f // this.mc.gameSettings.soundVolume != 0f */)
-+		{
-+			// The sound system is on a separate thread? Sync issues? Can get to crash by turning analyglph mode on?
-+
-+			sndSystem.setListenerPosition((float) interpolatedPlayerPos.xCoord, (float) interpolatedPlayerPos.yCoord, (float) interpolatedPlayerPos.zCoord);
-+			Vec3 hmd = mc.roomScale.getHMDDir_World();
-+			sndSystem.setListenerOrientation((float)hmd.xCoord,(float) hmd.yCoord,(float) hmd.zCoord,
-+					(float) up.xCoord, (float) up.yCoord, (float) up.zCoord);
-+		}
-+		//}
-+		if( mc.mumbleLink != null ) {
-+			Vec3 forward = Vec3.createVectorHelper(0, 0 , -1);
-+			forward.rotateAroundZ(-(float)cameraRoll * PIOVER180);
-+			forward.rotateAroundX(-(float)cameraPitch* PIOVER180);
-+			forward.rotateAroundY(-(float)cameraYaw  * PIOVER180);
-+			mc.mumbleLink.updateMumble(
-+					(float)interpolatedPlayerPos.xCoord,  (float)interpolatedPlayerPos.yCoord,  (float)interpolatedPlayerPos.zCoord,
-+					(float)forward.xCoord, (float)forward.yCoord, (float)forward.zCoord,
-+					(float)up.xCoord,      (float)up.yCoord,      (float)up.zCoord);
-+		}
 +	}
 +
 +	public void handleNotificationText()

--- a/src/com/mtbs3d/minecrift/api/IRoomscaleAdapter.java
+++ b/src/com/mtbs3d/minecrift/api/IRoomscaleAdapter.java
@@ -46,7 +46,8 @@ public interface IRoomscaleAdapter  {
 	public Vec3 getControllerOffhandDir_World(); 
 	public float getControllerOffhandYaw_World(); //degrees
 	public float getControllerOffhandPitch_World(); //degrees
-	
+
+	public Vec3 getCustomHMDVector(Vec3 axis);
 	public Vec3 getCustomControllerVector(int controller, Vec3 axis);
 	
 	public Vec3 getRoomOriginPos_World(); //degrees

--- a/src/com/mtbs3d/minecrift/provider/OpenVRPlayer.java
+++ b/src/com/mtbs3d/minecrift/provider/OpenVRPlayer.java
@@ -1196,9 +1196,17 @@ public class OpenVRPlayer implements IRoomscaleAdapter
 	}
 
 	@Override
+	public Vec3 getCustomHMDVector(Vec3 axis) {
+		Vector3f v3 = MCOpenVR.hmdRotation.transform(new Vector3f((float)axis.xCoord, (float)axis.yCoord, (float)axis.zCoord));
+		Vec3 out = Vec3.createVectorHelper(v3.x, v3.y, v3.z);
+		out.rotateAroundY(worldRotationRadians);
+		return out;
+	}
+
+	@Override
 	public Vec3 getCustomControllerVector(int controller, Vec3 axis) {
-		Vector3f v3 = MCOpenVR.getAimRotation(controller).transform(new Vector3f((float)axis.xCoord, (float)axis.yCoord,(float) axis.zCoord));
-		Vec3 out =  Vec3.createVectorHelper(v3.x, v3.y, v3.z);
+		Vector3f v3 = MCOpenVR.getAimRotation(controller).transform(new Vector3f((float)axis.xCoord, (float)axis.yCoord, (float)axis.zCoord));
+		Vec3 out = Vec3.createVectorHelper(v3.x, v3.y, v3.z);
 		out.rotateAroundY(worldRotationRadians);
 		return out;
 	}


### PR DESCRIPTION
Sound effects no longer rapidly flicker between left and right channels. This was happening because the listener position was being set twice per frame, before AND after the player position was updated.
