### PR TITLE
Fix mixedreality.fsh shader

### DIFF
--- a/assets/vivecraft/shaders/mixedreality.fsh
+++ b/assets/vivecraft/shaders/mixedreality.fsh
@@ -38,4 +38,4 @@ void main(void) {
 		discard; // Throw out the fragment to save some GPU processing
 		//out_Color = vec4(1, 0, 1, 1);
 	}
-};
+}


### PR DESCRIPTION
Ending a shader with `};` is a syntax error.

mesa:
```
shader_5.frag:/* Compile status: fail */
shader_5.frag-/* Log Info: */
shader_5.frag-0:41(2): error: syntax error, unexpected ';', expecting $end
```

glslangValidator;
```
mixedreality.frag
ERROR: 0:41: '' :  syntax error
ERROR: 1 compilation errors.  No code generated.
```