### PR TITLE
Add quick hotbar switching "backpack"

### DIFF
--- a/patches/net/minecraft/client/Minecraft.java.patch
+++ b/patches/net/minecraft/client/Minecraft.java.patch
@@ -85,6 +85,7 @@
 +import com.mtbs3d.minecrift.api.IRoomscaleAdapter;
 +import com.mtbs3d.minecrift.api.IStereoProvider;
 +import com.mtbs3d.minecrift.control.VRControllerButtonMapping;
++import com.mtbs3d.minecrift.gameplay.BackpackTracker;
 +import com.mtbs3d.minecrift.gameplay.BowTracker;
 +import com.mtbs3d.minecrift.gameplay.ClimbTracker;
 +import com.mtbs3d.minecrift.gameplay.EatingTracker;
@@ -1028,6 +1029,7 @@
 +	// VIVE START - teleport movement
 +	public OpenVRPlayer vrPlayer; 
 +	public IRoomscaleAdapter roomScale;
++	public BackpackTracker backpackTracker = new BackpackTracker();
 +	public BowTracker bowTracker = new BowTracker();
 +	public SwimTracker swimTracker = new SwimTracker();
 +	public EatingTracker autoFood=new EatingTracker();

--- a/src/com/mtbs3d/minecrift/gameplay/BackpackTracker.java
+++ b/src/com/mtbs3d/minecrift/gameplay/BackpackTracker.java
@@ -62,10 +62,13 @@ public void doProcess(Minecraft minecraft, EntityPlayerSP player){
 			if (wasIn[c]) {
 				// If we pressed while in the zone
 				if (wasPressed[c]) {
-					this.items[c] = player.getHeldItem().getItem();
+					ItemStack heldStack = player.getHeldItem();
+					this.items[c] = (heldStack == null ? null : heldStack.getItem());
 				} else {
-					player.inventory.setCurrentItem(this.items[c], 0, false, player.capabilities.isCreativeMode);
-					provider.triggerHapticPulse(c,1500);
+					if(this.items[c] != null) {
+						player.inventory.setCurrentItem(this.items[c], 0, false, player.capabilities.isCreativeMode);
+						provider.triggerHapticPulse(c, 1500);
+					}
 				}
 			}
 			// Reset state

--- a/src/com/mtbs3d/minecrift/gameplay/BackpackTracker.java
+++ b/src/com/mtbs3d/minecrift/gameplay/BackpackTracker.java
@@ -53,17 +53,19 @@ public void doProcess(Minecraft minecraft, EntityPlayerSP player){
 			wasIn[c] = true;
 			if(!wasPressed[c]) {
 				wasPressed[c] = Minecraft.getMinecraft().gameSettings.keyBindAttack.getIsKeyPressed();
+				if(wasPressed[c]) {
+					provider.triggerHapticPulse(c,1500);
+				}
 			}
 		} else {
 			// Only run once per zone entrance
 			if (wasIn[c]) {
-				provider.triggerHapticPulse(c,1500);
-
-				// If we came in pressing
+				// If we pressed while in the zone
 				if (wasPressed[c]) {
 					this.items[c] = player.getHeldItem().getItem();
 				} else {
 					player.inventory.setCurrentItem(this.items[c], 0, false, player.capabilities.isCreativeMode);
+					provider.triggerHapticPulse(c,1500);
 				}
 			}
 			// Reset state

--- a/src/com/mtbs3d/minecrift/gameplay/BackpackTracker.java
+++ b/src/com/mtbs3d/minecrift/gameplay/BackpackTracker.java
@@ -1,0 +1,74 @@
+package com.mtbs3d.minecrift.gameplay;
+
+import com.mtbs3d.minecrift.api.IRoomscaleAdapter;
+import com.mtbs3d.minecrift.provider.MCOpenVR;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.entity.EntityPlayerSP;
+import net.minecraft.item.EnumAction;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Vec3;
+
+import java.util.Random;
+
+/**
+ * Created by cincodenada on 13-May-17.
+ */
+public class BackpackTracker {
+	float mouthtoEyeDistance=0.0f;
+	float threshold=0.25f;
+	public Item[] items = new Item[2];
+	public boolean pressed;
+	public boolean wasIn;
+
+	public boolean isActive(EntityPlayerSP p){
+		if(Minecraft.getMinecraft().vrSettings.seated)
+			return false;
+		if(p == null) return false;
+		if(p.isDead) return false;
+		if(p.isPlayerSleeping()) return false;
+		return true;
+	}
+
+private Random r = new Random();
+
+	
+public void doProcess(Minecraft minecraft, EntityPlayerSP player){
+	if(!isActive(player)) {
+		return;
+	}
+	IRoomscaleAdapter provider = minecraft.roomScale;
+
+	Vec3 hmdPos=provider.getHMDPos_Room();
+
+	int c = 0;
+
+	Vec3 controllerPos=MCOpenVR.controllerHistory[c].averagePosition(0.333).add(provider.getCustomControllerVector(c,new Vec3(0,0,-0.1)));
+	controllerPos = controllerPos.add(minecraft.roomScale.getControllerDir_Room(c).scale(0.1));
+
+	if(
+			(Math.abs(hmdPos.yCoord - controllerPos.yCoord) < 0.25)
+			&& controllerPos.zCoord > hmdPos.zCoord
+			&& ((controllerPos.zCoord - hmdPos.zCoord) < 0.5)
+    ){
+		// Only run once per zone entrance
+		if(!wasIn) {
+			wasIn = true;
+
+			pressed = Minecraft.getMinecraft().gameSettings.keyBindAttack.getIsKeyPressed();
+
+			// If we came in pressing
+			if (pressed) {
+				this.items[c] = player.getHeldItem().getItem();
+			} else {
+			    player.inventory.setCurrentItem(this.items[c], 0, false, player.capabilities.isCreativeMode);
+			}
+
+		}
+	} else {
+		// Reset state
+		wasIn = false;
+	}
+}
+
+}

--- a/src/com/mtbs3d/minecrift/gameplay/BackpackTracker.java
+++ b/src/com/mtbs3d/minecrift/gameplay/BackpackTracker.java
@@ -19,6 +19,7 @@ public class BackpackTracker {
 	float threshold=0.25f;
 	public Item[] items = new Item[2];
 	public boolean[] wasIn = new boolean[2];
+	public boolean[] wasPressed = new boolean[2];
 
 	public boolean isActive(EntityPlayerSP p){
 		if(Minecraft.getMinecraft().vrSettings.seated)
@@ -49,24 +50,25 @@ public void doProcess(Minecraft minecraft, EntityPlayerSP player){
 						&& controllerPos.zCoord > hmdPos.zCoord
 						&& ((controllerPos.zCoord - hmdPos.zCoord) < 0.5)
 				) {
+			wasIn[c] = true;
+			if(!wasPressed[c]) {
+				wasPressed[c] = Minecraft.getMinecraft().gameSettings.keyBindAttack.getIsKeyPressed();
+			}
+		} else {
 			// Only run once per zone entrance
-			if (!wasIn[c]) {
-				wasIn[c] = true;
-
+			if (wasIn[c]) {
 				provider.triggerHapticPulse(c,1500);
 
-				boolean pressed = Minecraft.getMinecraft().gameSettings.keyBindAttack.getIsKeyPressed();
-
 				// If we came in pressing
-				if (pressed) {
+				if (wasPressed[c]) {
 					this.items[c] = player.getHeldItem().getItem();
 				} else {
 					player.inventory.setCurrentItem(this.items[c], 0, false, player.capabilities.isCreativeMode);
 				}
 			}
-		} else {
 			// Reset state
 			wasIn[c] = false;
+			wasPressed[c] = false;
 		}
 	}
 }

--- a/src/com/mtbs3d/minecrift/provider/OpenVRPlayer.java
+++ b/src/com/mtbs3d/minecrift/provider/OpenVRPlayer.java
@@ -222,7 +222,9 @@ public class OpenVRPlayer implements IRoomscaleAdapter
 	    mc.sneakTracker.doProcess(mc, player);
 	    
 		mc.autoFood.doProcess(mc,player);
-        
+
+        mc.backpackTracker.doProcess(mc, player);
+
         this.checkandUpdateRotateScale(false, 1);
 
 	    mc.swimTracker.doProcess(mc,player);


### PR DESCRIPTION
Playing Vivecraft is a blast, but sometimes a little too literally - I've found while playing that it's too hard quickly switch item slots precisely, meaning I can't quickly pull out my sword or bow when a
 creeper sneaks up on me.

Inspired by Space Pirate Trainer's gun/shield switching mechanic, I decided to try hacking in some functionality to allow (virtually) pinning a couple of items to your back, always ready for quick-access.

I'm a software dev by trade but I haven't done any modding before, so I'm poking around in the dark a bit here, but what I've got so far is pretty functional, I think, and worth a WIP pull request, I think.

I based it heavily off EatingTracker - the functionality is that if you put either controller behind your head and press the action key, the currently-held item (say, a sword) will be "pinned" to your back in a slot tied to that controller. Then you can switch back to whatever you want to work with and go on your merry way. If you need to pull out your sword quickly, you can just throw the same controller you pinned it with behind your back, and when you pull it out (without pressing action), you'll have the sword in hand.

I'm not super convinced that the action key is the best trigger, so I'm quite open to suggestions there, and on anything, really - like I said, I'm super new to fiddling with Minecraft mods. There's definitely some tidying (parameterization, etc) to do, but I wanted to get some early feedback with a proof-of-concept, so let me know what you think.

Also I'd love to have this in 1.11.2 as well. I haven't tried poking around, but the README said to poke you if I wanted help there.