### PR TITLE
Replaced repo.minecraft-vr.com to working reps

### DIFF
--- a/installer/1.7.10.json
+++ b/installer/1.7.10.json
@@ -185,7 +185,7 @@
     },
     {
       "name": "de.fruitfly.ovr:JRiftLibrary:0.8.0.0.1",
-	    "url": "http://repo.minecraft-vr.com/",
+	    "url": "http://vivecraft.org/jar/",
       "natives": {
         "linux": "natives-linux",
         "windows": "natives-windows",
@@ -199,7 +199,7 @@
     }, 
     {
       "name": "net.aib42.mumblelink:JMumbleLibrary:1.11",
-	    "url": "http://repo.minecraft-vr.com/",
+	    "url": "http://vivecraft.org/jar/",
       "natives": {
         "linux": "natives-linux",
         "windows": "natives-windows",
@@ -213,7 +213,7 @@
     },
     {
       "name": "com.sixense:SixenseJavaLibrary:062612.0",
-	    "url": "http://repo.minecraft-vr.com/",
+	    "url": "https://github.com/mabrowning/minecrift-repo/raw/gh-pages/",
       "natives": {
         "linux": "natives-linux",
         "windows": "natives-windows",

--- a/installer/1.7.10.json
+++ b/installer/1.7.10.json
@@ -108,10 +108,6 @@
       "url": "http://vivecraft.org/jar/"
     },
     {
-      "name": "net.aib42.mumblelink:JMumble:1.11",
-      "url": "http://vivecraft.org/jar/"
-    },    
-    {
       "name": "org.lwjgl.lwjgl:lwjgl-platform:2.9.1",
       "natives": {
         "linux": "natives-linux",
@@ -186,34 +182,6 @@
     {
       "name": "de.fruitfly.ovr:JRiftLibrary:0.8.0.0.1",
 	    "url": "http://vivecraft.org/jar/",
-      "natives": {
-        "linux": "natives-linux",
-        "windows": "natives-windows",
-        "osx": "natives-osx"
-      },
-      "extract": {
-        "exclude": [
-          "META-INF/"
-        ]
-      }
-    }, 
-    {
-      "name": "net.aib42.mumblelink:JMumbleLibrary:1.11",
-	    "url": "http://vivecraft.org/jar/",
-      "natives": {
-        "linux": "natives-linux",
-        "windows": "natives-windows",
-        "osx": "natives-osx"
-      },
-      "extract": {
-        "exclude": [
-          "META-INF/"
-        ]
-      }
-    },
-    {
-      "name": "com.sixense:SixenseJavaLibrary:062612.0",
-	    "url": "https://github.com/mabrowning/minecrift-repo/raw/gh-pages/",
       "natives": {
         "linux": "natives-linux",
         "windows": "natives-windows",


### PR DESCRIPTION
Looks like they were already replaced in newer versions, so I just changed it here. Except SixSense, but luckily, https://github.com/mabrowning/minecrift-repo/ was found.